### PR TITLE
feat: override more VS Code default theming

### DIFF
--- a/themes/LaserWave-color-theme.json
+++ b/themes/LaserWave-color-theme.json
@@ -78,10 +78,10 @@
         "diffEditor.removedTextBackground": "#eb64b940",
         "diffEditor.insertedTextBackground": "#74dfc440",
 
-        "peekViewEditor.background": "#40b4c43f",
+        "peekViewEditor.background": "#40b5c449",
         "peekView.border": "#40b4c4",
         "peekViewResult.matchHighlightBackground": "#27212e",
-        "peekViewEditor.matchHighlightBackground": "#27212e",
+        "peekViewEditor.matchHighlightBackground": "#40b5c460",
         "peekViewResult.selectionBackground": "#40b4c43f",
 
         "titleBar.inactiveBackground": "#27212e"

--- a/themes/LaserWave-color-theme.json
+++ b/themes/LaserWave-color-theme.json
@@ -63,7 +63,7 @@
 
         "list.activeSelectionBackground": "#eb64b98f",
         "list.activeSelectionForeground": "#eee",
-        "list.hoverBackground": "#EB64B98f",
+        "list.hoverBackground": "#eb64ba60",
         "list.hoverForeground": "#eee",
         "list.inactiveSelectionBackground": "#eb64b98f",
         "list.inactiveSelectionForeground": "#ddd",

--- a/themes/LaserWave-color-theme.json
+++ b/themes/LaserWave-color-theme.json
@@ -1,7 +1,7 @@
 {
     "name": "LaserWave",
     "colors": {
-        "focusBorder": "#40b4c4",
+        "focusBorder": "#EB64B9",
 
         "editor.foreground": "#ffffff",
         "editor.background": "#27212e",
@@ -58,7 +58,7 @@
         "terminal.ansiYellow": "#ffe261",
 
         "input.background": "#3a3242",
-        "input.border": "#EB64B9",
+        "input.border": "#964c7b",
         "inputOption.activeBorder": "#EB64B9",
 
         "list.activeSelectionBackground": "#eb64b98f",

--- a/themes/LaserWave-italic-color-theme.json
+++ b/themes/LaserWave-italic-color-theme.json
@@ -49,7 +49,7 @@
 
         "list.activeSelectionBackground": "#EB64B98f",
         "list.activeSelectionForeground": "#eee",
-        "list.hoverBackground": "#EB64B98f",
+        "list.hoverBackground": "#eb64ba60",
         "list.hoverForeground": "#eee",
         "list.inactiveSelectionBackground": "#EB64B98f",
         "list.inactiveSelectionForeground": "#ddd",

--- a/themes/LaserWave-italic-color-theme.json
+++ b/themes/LaserWave-italic-color-theme.json
@@ -1,7 +1,7 @@
 {
     "name": "LaserWave",
     "colors": {
-        "focusBorder": "#40b4c4",
+        "focusBorder": "#EB64B9",
         "editor.foreground": "#fff",
         "editor.background": "#27212e",
         "titleBar.activeBackground": "#27212e",
@@ -44,7 +44,7 @@
         "terminal.ansiYellow": "#ffe261",
 
         "input.background": "#3a3242",
-        "input.border": "#EB64B9",
+        "input.border": "#964c7b",
         "inputOption.activeBorder": "#EB64B9",
 
         "list.activeSelectionBackground": "#EB64B98f",

--- a/themes/LaserWave-italic-color-theme.json
+++ b/themes/LaserWave-italic-color-theme.json
@@ -64,10 +64,10 @@
         "diffEditor.removedTextBackground": "#eb64b940",
         "diffEditor.insertedTextBackground": "#74dfc440",
 
-        "peekViewEditor.background": "#40b4c43f",
+        "peekViewEditor.background": "#40b5c449",
         "peekView.border": "#40b4c4",
         "peekViewResult.matchHighlightBackground": "#27212e",
-        "peekViewEditor.matchHighlightBackground": "#27212e",
+        "peekViewEditor.matchHighlightBackground": "#40b5c460",
         "peekViewResult.selectionBackground": "#40b4c43f",
 
         "titleBar.inactiveBackground": "#27212e"


### PR DESCRIPTION
First, huge fan of this theme. I've been using it for over a year now.

Issue #16 got me thinking, are there more VS code defaults that could be themed using the Laserwave color palate? And so I ended up with some work that adds features, as well as some miscellaneous fixes.

Completely open to feedback, let me know if this PR seems too much and needs to be split into smaller PRs.

