### PR TITLE
define editor.selectionHighlightBackground.

### DIFF
--- a/themes/LaserWave-color-theme.json
+++ b/themes/LaserWave-color-theme.json
@@ -29,6 +29,7 @@
 
         "editor.wordHighlightBackground": "#eb64b927",
         "editor.selectionBackground":"#eb64b927",
+        "editor.selectionHighlightBackground": "#eb64b927",
         "editor.findMatchBackground":"#40b4c48c",
         "editor.findMatchHighlightBackground":"#40b4c460",
         "editorSuggestWidget.border": "#b4dce7",
@@ -47,7 +48,7 @@
         "merge.currentContentBackground": "#74dfc433",
         "merge.incomingHeaderBackground": "#40b4c4cc",
         "merge.incomingContentBackground": "#40b4c433",
-        
+
         "notifications.background": "#3e3549",
 
         "terminal.ansiBlue": "#40b4c4",

--- a/themes/LaserWave-italic-color-theme.json
+++ b/themes/LaserWave-italic-color-theme.json
@@ -21,6 +21,7 @@
         "tab.inactiveBackground": "#242029",
         "editor.wordHighlightBackground": "#eb64b927",
         "editor.selectionBackground":"#eb64b927",
+        "editor.selectionHighlightBackground": "#eb64b927",
         "editor.findMatchBackground":"#40b4c48c",
         "editor.findMatchHighlightBackground":"#40b4c460",
         "editorSuggestWidget.border": "#b4dce7",


### PR DESCRIPTION
I found the selection highlight for the matching content to be quite hard to see. This PR simply defines the value the same as the active highlight instead of it being an opacity change by the editor.

Old:
<img width="123" alt="Screen Shot 2020-02-14 at 3 08 24 PM" src="https://user-images.githubusercontent.com/532033/74567738-10666700-4f3c-11ea-87a9-35d6e2f5abcd.png">

New:
<img width="114" alt="Screen Shot 2020-02-14 at 3 08 01 PM" src="https://user-images.githubusercontent.com/532033/74567740-10666700-4f3c-11ea-9ab1-26a2bd910610.png">
