### PR TITLE
Set coherent color for menu.background

### DIFF
--- a/themes/LaserWave-color-theme.json
+++ b/themes/LaserWave-color-theme.json
@@ -2,6 +2,7 @@
     "name": "LaserWave",
     "colors": {
         "focusBorder": "#EB64B9",
+        "menu.background": "#27212e",
         "editor.foreground": "#ffffff",
         "editor.background": "#27212e",
         "titleBar.activeBackground": "#27212e",


### PR DESCRIPTION
This PR sets a color coherent with the theme for the drop-down menus of the menu bar.

| Before | After
-------- | ------
![Menu before](https://user-images.githubusercontent.com/49279289/87249177-c7203200-c45d-11ea-94ca-9de37e0aae02.png) | ![Menu after](https://user-images.githubusercontent.com/49279289/87249225-09497380-c45e-11ea-95bc-a77a6a4571d4.png)

