### PR TITLE
Set activityBar.activeBorder color to pink

### DIFF
--- a/themes/LaserWave-color-theme.json
+++ b/themes/LaserWave-color-theme.json
@@ -11,6 +11,7 @@
         "sideBarTitle.foreground": "#EB64B9",
         "activityBar.background": "#27212e",
         "activityBar.foreground": "#ddd",
+        "activityBar.activeBorder": "#EB64B9",
         "activityBarBadge.background": "#EB64B9",
         "statusBar.background": "#EB64B9",
         "statusBar.noFolderBackground": "#EB64B9",


### PR DESCRIPTION
This pull request is just a suggestion.

I propose to set the color of the border near the active icon in the activity bar to "hot pink".

| Before | After
--- | ---
![Active border before, in white](https://user-images.githubusercontent.com/49279289/87249588-44e53d00-c460-11ea-8dd3-f506c0c0732d.png) | ![Active border after, in pink](https://user-images.githubusercontent.com/49279289/87249604-575f7680-c460-11ea-8e70-a0538c05f37d.png)
