### PR TITLE
Add support for diff files

### DIFF
--- a/examples/example.diff
+++ b/examples/example.diff
@@ -1,0 +1,19 @@
+diff --git a/example.css b/example.css
+--- a/example.css
++++ b/example.css
+@@ -1,18 +1,19 @@
+ /* example comment */
+ @namespace
+ @namespace
+ .box {
+   border-radius: 4px;
+-  background-color: #F2F2F2;
++  background-color: SelectedItem;
++  color: SelectedItemText;
+ }
+ 
+ .circle {
+   border-radius: 25%;
+-  background-color: Field;
++  background-color: ButtonHighlight;
+ }

--- a/themes/LaserWave-color-theme.json
+++ b/themes/LaserWave-color-theme.json
@@ -456,6 +456,49 @@
       "settings": {
         "foreground": "#ffb85b"
       }
-    }
+    },
+    {
+      "name": "diff.header",
+      "scope": [
+        "meta.diff",
+        "meta.diff.header"
+      ],
+      "settings": {
+        "foreground": "#74dfc4",
+      }
+    },
+    {
+      "name": "diff.range",
+      "scope": [
+        "meta.diff.range.unified"
+      ],
+      "settings": {
+        "foreground": "#b381c5"
+      }
+    },
+    {
+      "name": "diff.deleted",
+      "scope": [
+        "markup.deleted",
+        "punctuation.definition.deleted.diff",
+        "punctuation.definition.from-file.diff",
+        "meta.diff.header.from-file"
+      ],
+      "settings": {
+        "foreground": "#eb64b9"
+      }
+    },
+    {
+      "name": "diff.inserted",
+      "scope": [
+        "markup.inserted",
+        "punctuation.definition.inserted.diff",
+        "punctuation.definition.to-file.diff",
+        "meta.diff.header.to-file"
+      ],
+      "settings": {
+        "foreground": "#40b4c4",
+      }
+    },
   ]
 }

--- a/themes/LaserWave-high-contrast-color-theme.json
+++ b/themes/LaserWave-high-contrast-color-theme.json
@@ -456,6 +456,49 @@
       "settings": {
         "foreground": "#ffb85b"
       }
-    }
+    },
+    {
+      "name": "diff.header",
+      "scope": [
+        "meta.diff",
+        "meta.diff.header"
+      ],
+      "settings": {
+        "foreground": "#3feabf",
+      }
+    },
+    {
+      "name": "diff.range",
+      "scope": [
+        "meta.diff.range.unified"
+      ],
+      "settings": {
+        "foreground": "#d887f5"
+      }
+    },
+    {
+      "name": "diff.deleted",
+      "scope": [
+        "markup.deleted",
+        "punctuation.definition.deleted.diff",
+        "punctuation.definition.from-file.diff",
+        "meta.diff.header.from-file"
+      ],
+      "settings": {
+        "foreground": "#ff52bf"
+      }
+    },
+    {
+      "name": "diff.inserted",
+      "scope": [
+        "markup.inserted",
+        "punctuation.definition.inserted.diff",
+        "punctuation.definition.to-file.diff",
+        "meta.diff.header.to-file"
+      ],
+      "settings": {
+        "foreground": "#1ed3ec",
+      }
+    },
   ]
 }


### PR DESCRIPTION
This change adds support for some common situations involving diff files.  Closes #40 

I didn't include it in this change but something I've seen in other themes is `punctuation.definition.changed.diff` but I couldn't figure out what it matched, so maybe that's something that can be added later once someone figures out what it corresponds to.