### PR TITLE
Set statusbarItem.remoteForeground to same value as statusBar.foreground

### DIFF
--- a/themes/LaserWave-color-theme.json
+++ b/themes/LaserWave-color-theme.json
@@ -44,6 +44,7 @@
     "statusBar.noFolderBackground": "#EB64B9",
     "statusBar.foreground": "#27212e",
     "statusBar.debuggingBackground": "#74dfc4",
+    "statusBarItem.remoteForeground": "#27212e",
 
     // Files
     "merge.currentHeaderBackground": "#74dfc4cc",

--- a/themes/LaserWave-high-contrast-color-theme.json
+++ b/themes/LaserWave-high-contrast-color-theme.json
@@ -44,6 +44,7 @@
     "statusBar.noFolderBackground": "#EB64B9",
     "statusBar.foreground": "#27212e",
     "statusBar.debuggingBackground": "#74dfc4",
+    "statusBarItem.remoteForeground": "#27212e",
 
     // Files
     "merge.currentHeaderBackground": "#74dfc4cc",


### PR DESCRIPTION
This pull request is a suggestion, please feel free to close it if it goes against your vision for the theme!

I propose that the foreground color for the Remote feature on the bottom left (`statusbarItem.remoteForeground`) be consistent with the value of the foreground of the rest of the status bar (`statusBar.foreground`).

For example, on `master`, this is what the Remote icon and text look like:
<img width="158" alt="master1" src="https://user-images.githubusercontent.com/6130147/151693681-e4f7c8f1-5fb4-46da-9e3f-b1461427d712.png">
<img width="267" alt="master2" src="https://user-images.githubusercontent.com/6130147/151693685-ae5d0e16-0cbe-4add-90a7-3b4bda36d192.png">

This patch will change the foreground color to `#27212e` to match the other status bar icons:
<img width="185" alt="patch1" src="https://user-images.githubusercontent.com/6130147/151693728-587bcd9d-f5cc-4858-8564-6faba2299702.png">
<img width="267" alt="patch2" src="https://user-images.githubusercontent.com/6130147/151693732-88afc4bc-dc43-47e5-8bae-53b188a37fa1.png">