### PR TITLE
HCL Syntax support

### DIFF
--- a/examples/example.tf
+++ b/examples/example.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.27"
+    }
+  }
+
+  required_version = ">= 0.14.9"
+}
+
+provider "aws" {
+  profile = "default"
+  region  = "us-west-2"
+}
+
+resource "aws_instance" "app_server" {
+  ami           = "ami-830c94e3"
+  instance_type = "t2.micro"
+
+  tags = {
+    Name = "ExampleAppServerInstance"
+  }
+}
+
+resource "aws_api_gateway_integration_response" "proxy_other" {
+  depends_on  = ["aws_api_gateway_integration.proxy_other"]
+  rest_api_id = "${aws_api_gateway_rest_api.this.id}"
+  resource_id = "${aws_api_gateway_resource.proxy_other.id}"
+  http_method = "${aws_api_gateway_method.proxy_other.http_method}"
+  status_code = "${aws_api_gateway_method_response.proxy_other.status_code}"
+
+  response_templates = {
+    "application/json" = ""
+  }
+}

--- a/themes/LaserWave-color-theme.json
+++ b/themes/LaserWave-color-theme.json
@@ -319,6 +319,7 @@
     {
       "name": "attributes",
       "scope": [
+        "variable.other.enummember",
         "entity.other.attribute-name",
         "entity.other.attribute-name.jsx",
         "entity.other.attribute-name.html",
@@ -378,6 +379,7 @@
     {
       "name": "variables",
       "scope": [
+        "variable.other",
         "variable.scss",
         "meta.function-call.c",
         "variable.parameter.ts",
@@ -415,6 +417,7 @@
     {
       "name": "Types",
       "scope": [
+        "entity.name.type",
         "storage.type",
         "keyword.var.go",
         "keyword.type.go",

--- a/themes/LaserWave-high-contrast-color-theme.json
+++ b/themes/LaserWave-high-contrast-color-theme.json
@@ -319,6 +319,7 @@
     {
       "name": "attributes",
       "scope": [
+        "variable.other.enummember",
         "entity.other.attribute-name",
         "entity.other.attribute-name.jsx",
         "entity.other.attribute-name.html",

--- a/themes/LaserWave-high-contrast-color-theme.json
+++ b/themes/LaserWave-high-contrast-color-theme.json
@@ -378,6 +378,7 @@
     {
       "name": "variables",
       "scope": [
+        "variable.other",
         "variable.scss",
         "meta.function-call.c",
         "variable.parameter.ts",
@@ -415,6 +416,7 @@
     {
       "name": "Types",
       "scope": [
+        "entity.name.type",
         "storage.type",
         "keyword.var.go",
         "keyword.type.go",


### PR DESCRIPTION
Fixes https://github.com/Jaredk3nt/laserwave/issues/44

cc @allankp

![Screen Shot 2022-11-06 at 5 50 08 PM](https://user-images.githubusercontent.com/115565899/200210435-f302309c-089b-491b-bf00-1ed219c46f33.png)

I took a "generic" approach here and just added the generic matches I found for the resource/name/variable scopes. We could alternatively suffix these with `.hcl/.terraform` but since I've never done vscode themes before I'm not sure if there's an advantage to that.