### PR TITLE
Add a sidebar border

### DIFF
--- a/themes/LaserWave-color-theme.json
+++ b/themes/LaserWave-color-theme.json
@@ -32,6 +32,7 @@
     "sideBar.foreground": "#ddd",
     "sideBarSectionHeader.background": "#27212e",
     "sideBarTitle.foreground": "#EB64B9",
+    "sideBar.border": "#eb64ba2b",
 
     // Activity Bar
     "activityBar.background": "#27212e",

--- a/themes/LaserWave-high-contrast-color-theme.json
+++ b/themes/LaserWave-high-contrast-color-theme.json
@@ -32,6 +32,7 @@
     "sideBar.foreground": "#ddd",
     "sideBarSectionHeader.background": "#27212e",
     "sideBarTitle.foreground": "#EB64B9",
+    "sideBar.border": "#ff00a292",
 
     // Activity Bar
     "activityBar.background": "#27212e",


### PR DESCRIPTION
I noticed I had a hard time finding the right spot to resize the sidebar, so I gave it a touch of border on the right:


![Screen Shot 2022-11-06 at 5 58 30 PM](https://user-images.githubusercontent.com/115565899/200211272-c47e6339-b167-455d-a38b-d980c0bffdbe.png)

More pronounced in high contrast mode:

![Screen Shot 2022-11-06 at 5 59 41 PM](https://user-images.githubusercontent.com/115565899/200211380-36e2b94b-fff0-46ae-b4e1-4307dea31019.png)
